### PR TITLE
feat: generate buildings by zone label

### DIFF
--- a/api.py
+++ b/api.py
@@ -6,7 +6,7 @@ import tempfile
 
 import shutil
 from typing import List
-from fastapi import FastAPI, HTTPException, UploadFile, File
+from fastapi import FastAPI, HTTPException, UploadFile, File, Query
 from fastapi.responses import FileResponse
 
 from pydantic import BaseModel
@@ -95,7 +95,10 @@ def start_train(req: TrainRequest):
 
 
 @app.post("/infer")
-async def infer_block(file: UploadFile = File(...)):
+async def infer_block(
+    zone_attr: str = Query(..., description="Name of attribute containing functional zone label"),
+    file: UploadFile = File(...),
+):
     """Generate building footprints for a block polygon.
 
     The uploaded file must contain a GeoJSON FeatureCollection with the block
@@ -109,7 +112,7 @@ async def infer_block(file: UploadFile = File(...)):
         raise HTTPException(status_code=400, detail="invalid GeoJSON")
 
     try:
-        result = infer_from_geojson(geojson)
+        result = infer_from_geojson(geojson, zone_attr)
     except Exception as e:  # pragma: no cover - safe guard
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,8 +46,9 @@ def test_infer_block_returns_geojson(monkeypatch):
         ],
     }
 
-    def fake_infer(geojson):
+    def fake_infer(geojson, zone_attr):
         assert geojson == input_geojson
+        assert zone_attr == "func_zone"
         return output_geojson
 
     monkeypatch.setattr("api.infer_from_geojson", fake_infer)
@@ -60,7 +61,7 @@ def test_infer_block_returns_geojson(monkeypatch):
         )
     }
 
-    response = client.post("/infer", files=files)
+    response = client.post("/infer", files=files, params={"zone_attr": "func_zone"})
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/geo+json")
     data = json.loads(response.content)


### PR DESCRIPTION
## Summary
- extend inference to use a functional zone attribute from uploaded GeoJSON
- require `zone_attr` query param in `/infer` endpoint and propagate to inference
- adapt API test for new parameter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a491ecc754833186341fa5928e321d