### PR TITLE
Fix transform params serialization to JSON

### DIFF
--- a/transform.py
+++ b/transform.py
@@ -455,7 +455,11 @@ def main():
     params_path = args.out_dir / "_transform_params.json"
     try:
         with params_path.open("w", encoding="utf-8") as fh:
-            json.dump(vars(args), fh, ensure_ascii=False, indent=2)
+            serialisable = {
+                k: (str(v) if isinstance(v, Path) else v)
+                for k, v in vars(args).items()
+            }
+            json.dump(serialisable, fh, ensure_ascii=False, indent=2)
     except Exception as e:  # pragma: no cover - logging best effort
         logger.error("Failed to write transform params: %s", e)
 


### PR DESCRIPTION
## Summary
- Ensure `transform.py` writes `_transform_params.json` successfully by converting `Path` objects to strings before JSON serialization

## Testing
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68beac546b68833197db8aaf0f83b1be