### PR TITLE
Skip invalid geometries during canonical transform

### DIFF
--- a/geo_utils.py
+++ b/geo_utils.py
@@ -58,18 +58,11 @@ def get_extend_line(a, b, block, isfront, is_extend_from_end = False):
                 nearest_points_on_contour = i
     elif intersect.geom_type == 'Point':
         nearest_points_on_contour = intersect
-    # elif intersect.geom_type == 'LineString':
-    #     if not is_extend_from_end:
-    #         nearest_points_on_contour = a
-    #     else:
-    #         nearest_points_on_contour = b
     else:
-        if not is_extend_from_end:
-            nearest_points_on_contour = a
-        else:
-            nearest_points_on_contour = b
-        print('intersect: ', intersect)
-        print('unknow geom type on intersection: ', intersect.geom_type)
+        # unsupported intersection geometry (e.g., LineString/empty)
+        raise NotImplementedError(
+            f"Unsupported intersection geometry: {intersect.geom_type}"
+        )
 
     if not is_extend_from_end:
         if isfront:

--- a/transform.py
+++ b/transform.py
@@ -102,6 +102,10 @@ def setup_logger(level: str = "INFO") -> logging.Logger:
 # --------------------- helpers ---------------------
 
 def shapely_to_skgeom_polygon(poly: Polygon):
+    if poly.geom_type != "Polygon":
+        raise NotImplementedError(
+            f"Unsupported block geometry: {poly.geom_type}"
+        )
     exterior_polyline = list(poly.exterior.coords)[:-1]
     exterior_polyline.reverse()
     return skgeom.Polygon(exterior_polyline)


### PR DESCRIPTION
## Summary
- skip blocks with non-Polygon geometry in canonical transform
- raise on unsupported boundary intersections to avoid LINESTRING Z EMPTY errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bee440fb7483319dbf935638144369