### PR TITLE
Add inference CLI script

### DIFF
--- a/inference_cli.py
+++ b/inference_cli.py
@@ -1,0 +1,67 @@
+import argparse
+import json
+from typing import Dict, Any, List
+
+from shapely.geometry import shape, mapping
+
+from inference import infer_from_geojson
+
+
+def _attach_buildings(blocks: Dict[str, Any], buildings: Dict[str, Any]) -> None:
+    """Attach building polygons to corresponding blocks in-place.
+
+    Each building is assigned to the first block whose geometry contains it.
+    If a building does not lie within any block it is ignored.
+    """
+    block_geoms: List[tuple[Any, Dict[str, Any]]] = []
+    for feat in blocks.get("features", []):
+        geom = shape(feat["geometry"])
+        block_geoms.append((geom, feat))
+
+    for b in buildings.get("features", []):
+        b_geom = shape(b["geometry"])
+        for geom, feat in block_geoms:
+            if geom.contains(b_geom):
+                props = feat.setdefault("properties", {})
+                lst = props.setdefault("buildings", [])
+                lst.append(mapping(b_geom))
+                break
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate building polygons for blocks")
+    parser.add_argument("--blocks", required=True, help="Path to GeoJSON with block polygons")
+    parser.add_argument("--buildings", help="Optional GeoJSON with existing buildings")
+    parser.add_argument("--model-repo", required=True, help="Path or HuggingFace repo with model weights")
+    parser.add_argument("--model-file", help="Specific model file name")
+    parser.add_argument("--hf-token", help="HuggingFace access token")
+    parser.add_argument("--n-buildings", type=int, default=5, help="Number of buildings to generate per block")
+    parser.add_argument("--zone-attr", default="zone", help="Name of zone attribute in input GeoJSON")
+    parser.add_argument("--output", required=True, help="Output GeoJSON file path")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
+    args = parser.parse_args()
+
+    with open(args.blocks, "r", encoding="utf-8") as f:
+        blocks_geojson = json.load(f)
+
+    if args.buildings:
+        with open(args.buildings, "r", encoding="utf-8") as f:
+            buildings_geojson = json.load(f)
+        _attach_buildings(blocks_geojson, buildings_geojson)
+
+    result = infer_from_geojson(
+        blocks_geojson,
+        block_counts=args.n_buildings,
+        zone_attr=args.zone_attr,
+        model_repo=args.model_repo,
+        model_file=args.model_file,
+        hf_token=args.hf_token,
+        verbose=args.verbose,
+    )
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(result, f)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/tests/test_inference_cli.py
+++ b/tests/test_inference_cli.py
@@ -1,0 +1,88 @@
+import json
+import pathlib
+import sys
+import types
+from shapely.geometry import Polygon, mapping
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+def _dummy_infer_buildings(block, n=5, zone_label=None):
+    minx, miny, maxx, maxy = block.bounds
+    buildings = []
+    if minx == maxx or miny == maxy:
+        return buildings
+    width = (maxx - minx) / (2 * n)
+    height = (maxy - miny) / 5
+    y0 = miny + (maxy - miny) * 0.1
+    for i in range(n):
+        x0 = minx + i * 2 * width
+        rect = Polygon([(x0, y0), (x0 + width, y0), (x0 + width, y0 + height), (x0, y0 + height)])
+        buildings.append(rect)
+    return buildings
+
+
+class DummyModel:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def load_state_dict(self, state):
+        pass
+
+    def eval(self):
+        return self
+
+    def infer(self, block, n=5, zone_label=None):
+        return _dummy_infer_buildings(block, n, zone_label)
+
+
+def test_cli_generates_buildings(tmp_path, monkeypatch):
+    fake_torch = types.SimpleNamespace(load=lambda *a, **k: {"model_state_dict": {}, "opt": {}})
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    fake_model = types.SimpleNamespace(BlockGenerator=DummyModel)
+    monkeypatch.setitem(sys.modules, "model", fake_model)
+
+    import inference_cli
+
+    block = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    blocks_geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"id": "b1", "zone": "residential"},
+                "geometry": mapping(block),
+            }
+        ],
+    }
+    blocks_path = tmp_path / "blocks.geojson"
+    blocks_path.write_text(json.dumps(blocks_geojson))
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "model.pt").write_text("dummy")
+
+    out_path = tmp_path / "out.geojson"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "inference_cli.py",
+            "--blocks",
+            str(blocks_path),
+            "--model-repo",
+            str(model_dir),
+            "--n-buildings",
+            "2",
+            "--output",
+            str(out_path),
+        ],
+    )
+
+    inference_cli.main()
+
+    result = json.loads(out_path.read_text())
+    assert result["type"] == "FeatureCollection"
+    assert len(result["features"]) == 2


### PR DESCRIPTION
## Summary
- add `inference_cli.py` to run model inference from the command line
- support optional existing buildings and writing output GeoJSON
- include test covering the CLI workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c009342c788331bb2e528acef7c472