### PR TITLE
Clean block geometry before mid-axis inverse warp

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -275,12 +275,10 @@ def _try_midaxis_inverse(
                 ext.append(ext[0])
             return skgeom.Polygon(list(reversed(ext)))  # важна ориентация
         
-        if not canon_block.is_valid:
-            try:
-                from shapely.validation import make_valid
-                canon_block = make_valid(canon_block)
-            except Exception:
-                canon_block = canon_block.buffer(0)
+        canon_block = canon_block.buffer(0)
+        canon_block = _make_valid(canon_block)
+        if not canon_block.is_simple:
+            raise ValueError("The input polygon is not simple.")
 
         sk_blk = _shapely_to_skgeom(canon_block)
         skel = skgeom.skeleton.create_interior_straight_skeleton(sk_blk)


### PR DESCRIPTION
## Summary
- Clean block polygon with `buffer(0)` and `make_valid` before mid-axis inverse warp
- Abort mid-axis warp when polygon is not simple

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*
- `pytest tests/test_inference.py tests/test_api.py tests/test_inference_cli.py -q` *(fails: shapely.errors.GEOSException: UnsupportedOperationException: getX called on empty Point)*

------
https://chatgpt.com/codex/tasks/task_e_68c033212c408331b88d4fbe36ee3beb